### PR TITLE
Moving GET and POST endpoints from /users to /api/users

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -11,6 +11,9 @@ apiRouter.get("/", (req, res, next):void => {
     }
 })
 
+import usersRouter from './users';
+apiRouter.use("/users", usersRouter);
+
 apiRouter.use((req, res): void => {
     res.status(404)
         .send({ message: 'Invalid API endpoint'});

--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -6,6 +6,8 @@ const prisma = new PrismaClient();
 const usersRouter = express.Router();
 
 // GET /api/users
+//TODO: Delete or restrict this endpoint to admin or logged in user.
+//TODO: Strip password for users object if this route is kept.
 
 usersRouter.get("/", async (req, res, next): Promise<void> => {
     try {
@@ -17,7 +19,7 @@ usersRouter.get("/", async (req, res, next): Promise<void> => {
 })
 
 // POST /api/users
-
+// TODO: Delete this endpoint when /api/users/register is added.
 usersRouter.post("/", async (req, res, next) => {
     try {
         const { email, username, password } = req.body;

--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -1,0 +1,37 @@
+import express from "express";
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+const usersRouter = express.Router();
+
+// GET /api/users
+
+usersRouter.get("/", async (req, res, next): Promise<void> => {
+    try {
+        const users = await prisma.user.findMany();
+        res.send({users});
+    } catch (e) {
+        next(e);
+    }
+})
+
+// POST /api/users
+
+usersRouter.post("/", async (req, res, next) => {
+    try {
+        const { email, username, password } = req.body;
+        const user = await prisma.user.create({
+            data: {
+                email,
+                username,
+                password
+            }
+        })
+        res.send({user});
+    } catch (e) {
+        next(e)
+    }
+})
+
+export default usersRouter;

--- a/src/api/zoops.ts
+++ b/src/api/zoops.ts
@@ -1,0 +1,36 @@
+import express from "express";
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+const zoopsRouter = express.Router();
+
+// GET /api/zoops
+
+zoopsRouter.get("/", async (req, res, next): Promise<void> => {
+    try {
+        const zoops = await prisma.zoop.findMany();
+        res.send({zoops});
+    } catch (e) {
+        next(e);
+    }
+})
+
+// POST /api/zoops
+
+zoopsRouter.post("/", async (req, res, next): Promise<void> => {
+    try {
+        const {content, authorId, receiverId} = req.body;
+        const zoop = await prisma.zoop.create({
+            data: {
+                content,
+                authorId,
+                receiverId
+            }
+        })
+    } catch (e) {
+
+    }
+})
+
+export default zoopsRouter;

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,27 +20,6 @@ app.get("/", (req: Request, res: Response, next: NextFunction): void => {
 import apiRouter from "./api";
 app.use("/api", apiRouter);
 
-app.get("/users", async (req, res, next) => {
-  try {
-    const users = await prisma.user.findMany();
-    res.send({ users });
-  } catch (e) {
-    next(e);
-  }
-});
-
-app.post("/users", async (req, res) => {
-  const { email, username, password } = req.body;
-  const user = await prisma.user.create({
-    data: {
-      email,
-      username,
-      password,
-    },
-  });
-  res.send({ user });
-});
-
 const { PORT = 3000 } = process.env;
 
 app.listen(PORT, () => {


### PR DESCRIPTION
## Description
Moved GET and POST users endpoints from `index.ts` file to a `users.ts` file and switched the endpoint from /users to /api/users. These endpoints are primarily for testing at this point, but POSTing a user will eventually involve registering at a /api/users/register endpoint.

## Related Issue
Closes #2 

## Checklist
 - [x] Created tests which fail without the change (if possible)
 - [x] Confirmed all tests are passing
 
## How Has This Been Tested?
Postman

![Screen Shot 2023-10-17 at 10 07 34](https://github.com/dyazdani/zoop/assets/99094815/a296abab-9060-42fa-9197-29269d695011)
![Screen Shot 2023-10-17 at 10 08 41](https://github.com/dyazdani/zoop/assets/99094815/d49e124d-73ee-4724-b0db-419bff09bd78)

