### PR TITLE
Add GET /api/zoops/:id

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,19 +1,21 @@
-import express from 'express';
+import express from "express";
 
 const apiRouter = express.Router();
 
 // GET /api
-apiRouter.get("/", (req, res, next):void => {
-    try {
-        res.send('API is live');
-    } catch(e) {
-        next(e);
-    }
-})
+apiRouter.get("/", (req, res, next): void => {
+  try {
+    res.send("API is live");
+  } catch (e) {
+    next(e);
+  }
+});
+
+import zoopsRouter from "./zoops";
+apiRouter.use("/zoops", zoopsRouter);
 
 apiRouter.use((req, res): void => {
-    res.status(404)
-        .send({ message: 'Invalid API endpoint'});
-})
+  res.status(404).send({ message: "Invalid API endpoint" });
+});
 
 export default apiRouter;

--- a/src/api/zoops.ts
+++ b/src/api/zoops.ts
@@ -1,0 +1,23 @@
+import express from "express";
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+const zoopsRouter = express.Router();
+
+// Get /api/zoops/:id
+zoopsRouter.get("/:id", async (req, res, next) => {
+  try {
+    const zoopId = Number(req.params.id);
+    const zoop = await prisma.zoop.findFirst({
+      where: {
+        id: zoopId,
+      },
+    });
+    res.send({ zoop });
+  } catch (e) {
+    next(e);
+  }
+});
+
+export default zoopsRouter;


### PR DESCRIPTION
## Description
Creating endpoint for GET /api/zoops/:id

## Related Issue
Closes https://github.com/dyazdani/zoop/issues/7

## Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Confirmed all tests are passing

## How Has This Been Tested?
Via Postman, tested that a get to the zoops/:id endpoint successfully returned the customer with the correct id

![Screenshot 2023-10-17 at 9 21 03 AM](https://github.com/dyazdani/zoop/assets/31025639/40b4ee09-79b8-4041-a94d-d93097be628a)

![Screenshot 2023-10-17 at 11 11 27 AM](https://github.com/dyazdani/zoop/assets/31025639/60b64275-4266-42ad-a539-c3a11c4e8bd0)

