### PR TITLE
Added DELETE zoops/:id/faves endpoint

### DIFF
--- a/src/api/zoops.ts
+++ b/src/api/zoops.ts
@@ -118,4 +118,25 @@ zoopsRouter.post("/:id/faves", requireUser, async (req: any, res, next): Promise
     }
 })
 
+  // DELETE /api/zoops/:id/faves
+  zoopsRouter.delete("/:id/faves", requireUser, async (req: any, res, next): Promise<void> => {
+    const userId = req.user?.id;
+
+    try {
+        const { id } = req.params;
+        const fave = await prisma.fave.findFirstOrThrow({
+            where: {
+                zoopId: Number(id), 
+                faverId: Number(userId)
+            }
+        })
+        
+        res.send({fave});
+
+    } catch (e) {
+        next(e);
+    }
+})
+
+
 export default zoopsRouter;

--- a/src/api/zoops.ts
+++ b/src/api/zoops.ts
@@ -124,14 +124,18 @@ zoopsRouter.post("/:id/faves", requireUser, async (req: any, res, next): Promise
 
     try {
         const { id } = req.params;
-        const fave = await prisma.fave.findFirstOrThrow({
+        const fave = await prisma.fave.findFirst({
             where: {
                 zoopId: Number(id), 
                 faverId: Number(userId)
             }
         })
         
-        res.send({fave});
+        if (!fave) {
+            next({name: "NotFound", message: "Could not find fave"})
+        } else {
+            res.send({fave});
+        }
 
     } catch (e) {
         next(e);


### PR DESCRIPTION
Closes #13 and #29 

Is it OK that it returns an error saying "no fave found" when the user tries to delete a fave from a zoop when they have not faved the zoop (see postman screenshot below)? Of should I throw some sort of status code instead?

Also, when I send the Delete request multiple times, it keeps sending the deleted fave. Shouldn't it not work a second time because the fave is deleted? If needed, I'll create a debugging route to GET all faves on a zoop and see if the fave stays after the DELETE request.

Screenshots from testing in Postman:
![Screen Shot 2023-11-05 at 07 55 14](https://github.com/dyazdani/zoop/assets/99094815/1da786b9-15a9-4e87-8d1b-78e1b545a35b)
![Screen Shot 2023-11-05 at 07 55 59](https://github.com/dyazdani/zoop/assets/99094815/8c2846da-bd4e-44e6-b3f9-35b4ac55fef4)
![Screen Shot 2023-11-05 at 07 56 33](https://github.com/dyazdani/zoop/assets/99094815/a68256ed-5f95-47fe-bff5-9b82a8d890f1)
