### PR TITLE
Authorization for PUT /zoops/:id

### DIFF
--- a/src/api/zoops.ts
+++ b/src/api/zoops.ts
@@ -58,11 +58,14 @@ zoopsRouter.put("/:id", requireUser, async (req, res, next)=> {
     const userId = req.user?.id;
     const {id} = req.params;
 
-    const zoop = await prisma.zoop.findUniqueOrThrow({
+    const zoop = await prisma.zoop.findUnique({
         where: {id: Number(id)}
     });
 
-    if (zoop.authorId === userId) {
+    if (!zoop) {
+        res.status(404)
+            .send({name: "NotFound", message: "Zoop with ID not found"})
+    } else if (zoop.authorId === userId) {
         try {
             const {content} = req.body;
             const zoop = await prisma.zoop.update({

--- a/src/api/zoops.ts
+++ b/src/api/zoops.ts
@@ -75,7 +75,7 @@ zoopsRouter.put("/:id", requireUser, async (req, res, next)=> {
         }
     } else {
         res.status(403)
-            .send({message: "Only author of zoop can delete zoop"}) 
+            .send({message: "Only author of zoop can update zoop"}) 
     }
 
 

--- a/src/api/zoops.ts
+++ b/src/api/zoops.ts
@@ -55,17 +55,30 @@ zoopsRouter.post("/", requireUser, async (req, res, next): Promise<void> => {
 
 // PUT /api/zoops/:id
 zoopsRouter.put("/:id", requireUser, async (req, res, next)=> {
-    try {
-        const {id} = req.params;
-        const {content} = req.body;
-        const zoop = await prisma.zoop.update({
-            where: {id: Number(id)},
-            data: {content}
-        })
-        res.send({zoop});
-    } catch (e) {
-        next(e);
+    const userId = req.user?.id;
+    const {id} = req.params;
+
+    const zoop = await prisma.zoop.findUniqueOrThrow({
+        where: {id: Number(id)}
+    });
+
+    if (zoop.authorId === userId) {
+        try {
+            const {content} = req.body;
+            const zoop = await prisma.zoop.update({
+                where: {id: Number(id)},
+                data: {content}
+            })
+            res.send({zoop});
+        } catch (e) {
+            next(e);
+        }
+    } else {
+        res.status(403)
+            .send({message: "Only author of zoop can delete zoop"}) 
     }
+
+
 })
 
 


### PR DESCRIPTION
Closes #30 

Currently unable to get the code to prohibit user who did not create zoop from editing zoop. Console logs in the endpoint code are also not logging for me.