### PR TITLE
Refactored /api/zoops/:id/faves to api/faves

### DIFF
--- a/src/api/faves.ts
+++ b/src/api/faves.ts
@@ -1,0 +1,35 @@
+import express from 'express';
+import { PrismaClient } from "@prisma/client";
+import requireUser from "../utils/requireUser";
+
+const prisma = new PrismaClient();
+
+const favesRouter = express.Router();
+
+
+// POST /api/faves
+favesRouter.post("/", requireUser, async (req, res, next): Promise<void> => {
+    try {
+        const {zoopId} = req.body;
+        const zoop = await prisma.zoop.findUniqueOrThrow({
+            where: {id: Number(zoopId)}
+        });
+        const faverId = Number(req.user?.id);
+        if (Number(zoop.authorId) !== faverId) {
+            const fave = await prisma.fave.create({
+                data: {
+                    faverId: faverId,
+                    zoopId: zoopId
+                }
+            })
+            res.send({fave});
+        } else {
+            res.status(403)
+                .send({message: 'Cannot fave your own Zoops'})
+        }
+    } catch (e) {
+        next(e);
+    }
+})
+
+export default favesRouter;

--- a/src/api/faves.ts
+++ b/src/api/faves.ts
@@ -32,4 +32,35 @@ favesRouter.post("/", requireUser, async (req, res, next): Promise<void> => {
     }
 })
 
+// DELETE /api/faves/:id
+favesRouter.delete("/:id", requireUser, async (req: any, res, next): Promise<void> => {
+    try {
+        const userId = req.user?.id;
+        const { faveId } = req.body;
+        const fave = await prisma.fave.findUniqueOrThrow({
+            where: {
+                id: Number(faveId) 
+            }
+        })
+        
+        if (!fave) {
+            next({name: "NotFound", message: "Could not find fave"})
+        } else if (userId === fave.faverId) {
+            const deletedFave = await prisma.fave.delete({
+                where: {
+                    id: faveId
+                }
+            })
+
+            res.send({deletedFave});
+        } else {
+            res.status(403)
+                .send({message: "Only author of fave can delete fave"});
+        }
+    } catch (e) {
+        next(e);
+    }
+})
+
+
 export default favesRouter;

--- a/src/api/faves.ts
+++ b/src/api/faves.ts
@@ -52,7 +52,7 @@ favesRouter.delete("/:id", requireUser, async (req: any, res, next): Promise<voi
                 }
             })
 
-            res.send({deletedFave});
+            res.send({success: true});
         } else {
             res.status(403)
                 .send({message: "Only author of fave can delete fave"});

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -14,6 +14,9 @@ apiRouter.get("/", (req, res, next): void => {
 import zoopsRouter from "./zoops";
 apiRouter.use("/zoops", zoopsRouter);
 
+import favesRouter from "./faves";
+apiRouter.use("/faves", favesRouter);
+
 import usersRouter from './users';
 apiRouter.use("/users", usersRouter);
 

--- a/src/api/zoops.ts
+++ b/src/api/zoops.ts
@@ -93,29 +93,4 @@ zoopsRouter.delete(`/:id`, requireUser, async (req, res, next) => {
     }
   })
 
-  // POST /api/zoops/:id/faves
-zoopsRouter.post("/:id/faves", requireUser, async (req: any, res, next): Promise<void> => {
-    try {
-        const id = Number(req.params.id);
-        const zoop = await prisma.zoop.findUniqueOrThrow({
-            where: {id: id}
-        });
-        const faverId = Number(req.user.id);
-        if (Number(zoop.authorId) !== faverId) {
-            const fave = await prisma.fave.create({
-                data: {
-                    faverId: faverId,
-                    zoopId: id
-                }
-            })
-            res.send({fave});
-        } else {
-            res.status(403)
-                .send({message: 'Cannot fave your own Zoops'})
-        }
-    } catch (e) {
-        next(e);
-    }
-})
-
 export default zoopsRouter;


### PR DESCRIPTION
Closes #39, #33, #34

Refactored with authorization for endpoints included.

Postman testing:
![Screen Shot 2023-11-05 at 14 57 19](https://github.com/dyazdani/zoop/assets/99094815/6613da0f-c80a-43cb-a9b8-c0ee4db5bea6)
![Screen Shot 2023-11-05 at 15 00 56](https://github.com/dyazdani/zoop/assets/99094815/fef60da5-8ad2-4b3f-a009-611ffce392c7)
![Screen Shot 2023-11-05 at 15 21 12](https://github.com/dyazdani/zoop/assets/99094815/73d993b3-1cef-47c0-935d-3058ebd966e0)
![Screen Shot 2023-11-05 at 15 21 32](https://github.com/dyazdani/zoop/assets/99094815/958b1406-95de-4b0a-8cb4-8f89c1d55371)
![Screen Shot 2023-11-05 at 15 21 40](https://github.com/dyazdani/zoop/assets/99094815/5787f661-6e00-4134-9c1d-7ef50828d5aa)
