### PR TITLE
Added unique constraint to Faves model

### DIFF
--- a/prisma/migrations/20231107003430_/migration.sql
+++ b/prisma/migrations/20231107003430_/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[faverId,zoopId]` on the table `Fave` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "Fave_faverId_zoopId_key" ON "Fave"("faverId", "zoopId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -45,4 +45,6 @@ model Fave {
 
   zoop   Zoop @relation("Zoop", fields: [zoopId], references: [id])
   zoopId Int
+
+  @@unique([faverId, zoopId])
 }


### PR DESCRIPTION
Closes #36 

Now when a user tries to fave the same zoop twice, they get the following error: 
![Screen Shot 2023-11-06 at 16 40 00](https://github.com/dyazdani/zoop/assets/99094815/d36dd165-9b78-4e59-a35c-6dc692170e60)


I would like the error message to be clearer like, "You cannot fave a zoop more than once." However, when I tried to insert some logic into the route, for some reason it could not find the faves property on a zoop, which is supposed to be an array of faves. Do you know why this might be? I migrated with prisma just before the last commit on this branch.

![Screen Shot 2023-11-06 at 16 54 20](https://github.com/dyazdani/zoop/assets/99094815/76b352ca-e9cb-4b55-80ac-2347f4fb3e73)
