### PR TITLE
Send a Zoop Feature

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -8,6 +8,7 @@ import { RootState } from "./app/store";
 import MePage from "./components/MePage";
 import HomePage from "./components/HomePage";
 import Nav from "./components/Nav";
+import SendZoopDialog from "./components/SendZoopDialog";
 
 const App: React.FC = () => {
   const token = useSelector((state: RootState) => state.auth.token);
@@ -19,6 +20,9 @@ const App: React.FC = () => {
 
   return (
     <>
+      {token && (
+        <SendZoopDialog />
+      )}
       <Nav />
       <Routes>
         <Route path="/" element={<HomePage />}/>

--- a/client/App.tsx
+++ b/client/App.tsx
@@ -8,7 +8,7 @@ import { RootState } from "./app/store";
 import MePage from "./components/MePage";
 import HomePage from "./components/HomePage";
 import Nav from "./components/Nav";
-import SendZoopDialog from "./components/SendZoopDialog";
+import SendZoopButton from "./components/SendZoopButton";
 
 const App: React.FC = () => {
   const token = useSelector((state: RootState) => state.auth.token);
@@ -21,7 +21,7 @@ const App: React.FC = () => {
   return (
     <>
       {token && (
-        <SendZoopDialog />
+        <SendZoopButton />
       )}
       <Nav />
       <Routes>

--- a/client/components/HomePage.tsx
+++ b/client/components/HomePage.tsx
@@ -1,23 +1,15 @@
 import React from "react";
 import ZoopList from './ZoopList'
-import Fab from "@mui/material/Fab";
-import SendIcon from "@mui/icons-material/Send";
+import SendZoopDialog from "./SendZoopDialog";
 
 const HomePage = () => {
-    return(
+
+   
+    return (
         <>
             <div>I am the Home Page</div>
             <ZoopList />
-            <Fab
-                sx={{
-                    position: "absolute",
-                    bottom: 25,
-                    right: 25
-                }}
-                // TODO: Set up onClick={}
-            > <SendIcon />
-
-            </Fab>
+            <SendZoopDialog />
         </>
     )
 }

--- a/client/components/HomePage.tsx
+++ b/client/components/HomePage.tsx
@@ -1,11 +1,23 @@
 import React from "react";
 import ZoopList from './ZoopList'
+import Fab from "@mui/material/Fab";
+import SendIcon from "@mui/icons-material/Send";
 
 const HomePage = () => {
     return(
         <>
             <div>I am the Home Page</div>
             <ZoopList />
+            <Fab
+                sx={{
+                    position: "absolute",
+                    bottom: 25,
+                    right: 25
+                }}
+                // TODO: Set up onClick={}
+            > <SendIcon />
+
+            </Fab>
         </>
     )
 }

--- a/client/components/HomePage.tsx
+++ b/client/components/HomePage.tsx
@@ -9,7 +9,6 @@ const HomePage = () => {
         <>
             <div>I am the Home Page</div>
             <ZoopList />
-            <SendZoopDialog />
         </>
     )
 }

--- a/client/components/HomePage.tsx
+++ b/client/components/HomePage.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import ZoopList from './ZoopList'
-import SendZoopDialog from "./SendZoopDialog";
 
 const HomePage = () => {
 

--- a/client/components/MePage.tsx
+++ b/client/components/MePage.tsx
@@ -1,9 +1,17 @@
 import React from "react";
+import SendZoopDialog from "./SendZoopDialog";
 
 const MePage = () => {
-  return <p>I am the Me Page. 
+  return (
+    <>
+    <p>I am the Me Page. 
     This is the page for all the Zoops I received, all the Zoops I created, 
-    and all the Zoops I Fave’d</p>;
+    and all the Zoops I Fave’d</p>
+    <SendZoopDialog />
+    </>
+    
+  )
+    
 };
 
 export default MePage;

--- a/client/components/MePage.tsx
+++ b/client/components/MePage.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import SendZoopDialog from "./SendZoopDialog";
 
 const MePage = () => {
   return (

--- a/client/components/MePage.tsx
+++ b/client/components/MePage.tsx
@@ -7,7 +7,6 @@ const MePage = () => {
     <p>I am the Me Page. 
     This is the page for all the Zoops I received, all the Zoops I created, 
     and all the Zoops I Fave’d</p>
-    <SendZoopDialog />
     </>
     
   )

--- a/client/components/SendZoopButton.tsx
+++ b/client/components/SendZoopButton.tsx
@@ -30,7 +30,9 @@ const SendZoopButton = () => {
                         right: 25
                     }}
                     onClick={() => setIsDialogOpen(true)}
-                >Send Zoop  ----<SendIcon />
+                    endIcon={<SendIcon />}
+                >
+                    Send Zoop
                 </Button>
             )}
 

--- a/client/components/SendZoopButton.tsx
+++ b/client/components/SendZoopButton.tsx
@@ -14,6 +14,10 @@ const SendZoopButton = () => {
     // Variable used for authorization
     const token = useSelector((state: RootState) => state.auth.token);
 
+    if (!token) {
+        return null
+    }
+
     return (
         <>
             {token && (

--- a/client/components/SendZoopButton.tsx
+++ b/client/components/SendZoopButton.tsx
@@ -1,0 +1,60 @@
+import Fab from "@mui/material/Fab";
+import SendIcon from "@mui/icons-material/Send";
+import React, {
+    useState,
+} from "react";
+import { useSelector } from "react-redux";
+
+import { RootState} from "../app/store";
+import SendZoopDialog from "./SendZoopDialog";
+import ZoopSentDialog from "./ZoopSentDialog";
+import { Zoop } from "../../src/types/custom";
+
+const SendZoopButton = () => {
+    const [open, setOpen] = useState(false);
+    const [isZoopSent, setIsZoopSent] = useState(false);
+    const [sentZoop, setSentZoop] = useState<Zoop | null>(null)
+
+    // Variable used for authorization
+    const token = useSelector((state: RootState) => state.auth.token);
+
+    const handleSetSentZoop = (zoop: Zoop) => {
+        setSentZoop(zoop);
+    }
+
+    return (
+        <>
+            {token && (
+                <Fab
+                    disabled={!token}
+                    sx={{
+                        position: "absolute",
+                        top: 25,
+                        right: 25
+                    }}
+                    onClick={() => setOpen(true)}
+                > <SendIcon />
+                </Fab>
+            )}
+
+
+            {open && (
+                <SendZoopDialog 
+                    openDialog={open}
+                    isZoopSent={() => setIsZoopSent(true)}
+                    sentZoop={handleSetSentZoop}
+                />
+            )}
+            
+            {isZoopSent && (
+                <ZoopSentDialog
+                    isZoopSent={isZoopSent}
+                    sentZoop={sentZoop}
+                />
+            )}
+            
+        </>
+    )
+};
+
+export default SendZoopButton;

--- a/client/components/SendZoopButton.tsx
+++ b/client/components/SendZoopButton.tsx
@@ -11,16 +11,10 @@ import ZoopSentDialog from "./ZoopSentDialog";
 import { Zoop } from "../../src/types/custom";
 
 const SendZoopButton = () => {
-    const [open, setOpen] = useState(false);
-    const [isZoopSent, setIsZoopSent] = useState(false);
-    const [sentZoop, setSentZoop] = useState<Zoop | null>(null)
+    const [isDialogOpen, setIsDialogOpen] = useState(false);
 
     // Variable used for authorization
     const token = useSelector((state: RootState) => state.auth.token);
-
-    const handleSetSentZoop = (zoop: Zoop) => {
-        setSentZoop(zoop);
-    }
 
     return (
         <>
@@ -32,24 +26,16 @@ const SendZoopButton = () => {
                         top: 25,
                         right: 25
                     }}
-                    onClick={() => setOpen(true)}
+                    onClick={() => setIsDialogOpen(true)}
                 > <SendIcon />
                 </Fab>
             )}
 
 
-            {open && (
+            {isDialogOpen && (
                 <SendZoopDialog 
-                    openDialog={open}
-                    isZoopSent={() => setIsZoopSent(true)}
-                    sentZoop={handleSetSentZoop}
-                />
-            )}
-            
-            {isZoopSent && (
-                <ZoopSentDialog
-                    isZoopSent={isZoopSent}
-                    sentZoop={sentZoop}
+                    open={isDialogOpen}
+                    onClose={() => setIsDialogOpen(false)}
                 />
             )}
             

--- a/client/components/SendZoopButton.tsx
+++ b/client/components/SendZoopButton.tsx
@@ -1,4 +1,4 @@
-import Fab from "@mui/material/Fab";
+import Button from "@mui/material/Button";
 import SendIcon from "@mui/icons-material/Send";
 import React, {
     useState,
@@ -7,8 +7,6 @@ import { useSelector } from "react-redux";
 
 import { RootState} from "../app/store";
 import SendZoopDialog from "./SendZoopDialog";
-import ZoopSentDialog from "./ZoopSentDialog";
-import { Zoop } from "../../src/types/custom";
 
 const SendZoopButton = () => {
     const [isDialogOpen, setIsDialogOpen] = useState(false);
@@ -19,16 +17,17 @@ const SendZoopButton = () => {
     return (
         <>
             {token && (
-                <Fab
+                <Button
                     disabled={!token}
+                    variant="contained"
                     sx={{
                         position: "absolute",
                         top: 25,
                         right: 25
                     }}
                     onClick={() => setIsDialogOpen(true)}
-                > <SendIcon />
-                </Fab>
+                >Send Zoop  ----<SendIcon />
+                </Button>
             )}
 
 

--- a/client/components/SendZoopDialog.tsx
+++ b/client/components/SendZoopDialog.tsx
@@ -6,6 +6,7 @@ import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
 import TextField from "@mui/material/TextField";
 import React, { useState } from "react";
+import { useSelector } from "react-redux";
 
 import { 
     useGetAllUsersQuery, 
@@ -14,6 +15,7 @@ import {
 } from "../features/api";
 import { Zoop } from "../../src/types/custom";
 import ZoopSentDialog from "./ZoopSentDialog";
+import { RootState } from "../app/store";
 
 export interface SendZoopDialogProps {
     open: boolean
@@ -24,7 +26,7 @@ const SendZoopDialog = ({open, onClose}: SendZoopDialogProps) => {
     const [username, setUsername] = useState("");
     const [content, setContent] = useState("");
 
-    const currentUser = useGetMeQuery().data;
+    const currentUser = useSelector((state: RootState) => state.auth.user)
 
     const [sendZoop, { isLoading: isSendZoopLoading, isError, data: zoopData, error: zoopError }] = useSendZoopMutation();
     const {data: usersData, isLoading: isGetAllUsersLoading, error: userError } = useGetAllUsersQuery(); 
@@ -49,7 +51,7 @@ const SendZoopDialog = ({open, onClose}: SendZoopDialogProps) => {
             if (recipient && currentUser) {
                 sendZoop({
                     content: content,
-                    authorId: currentUser.user.id,
+                    authorId: currentUser.id,
                     receiverId: recipient.user.id
                 })
             } else {

--- a/client/components/SendZoopDialog.tsx
+++ b/client/components/SendZoopDialog.tsx
@@ -37,12 +37,14 @@ const SendZoopDialog = () => {
                     placeholder="Username"    
                 />
                 <TextField
-                    autoFocus
                     required
+                    fullWidth
+                    multiline
+                    minRows={5}
                     margin="dense"
                     label="Content"
                     type="text"
-                    placeholder="e.g., Zoop is the zoopiest of all apps."    
+                    placeholder="e.g., Zoop is the new hotness."    
                 />    
             </DialogContent>
             <DialogActions>

--- a/client/components/SendZoopDialog.tsx
+++ b/client/components/SendZoopDialog.tsx
@@ -1,73 +1,148 @@
-import React, {useState} from "react";
+import React, {useState } from "react";
+import {useNavigate} from "react-router-dom";
 import Dialog from "@mui/material/Dialog";
 import DialogTitle from "@mui/material/DialogTitle";
 import DialogContent from "@mui/material/DialogContent";
+import DialogContentText from "@mui/material/DialogContentText"
 import DialogActions from "@mui/material/DialogActions";
 import Button from "@mui/material/Button";
 import TextField from "@mui/material/TextField";
+import Link from "@mui/material/Link";
 import Tooltip from "@mui/material/Tooltip";
 import Fab from "@mui/material/Fab";
 import SendIcon from "@mui/icons-material/Send";
+import { 
+    usePostZoopMutation, 
+    useGetAllUsersQuery,
+    useGetMeQuery
+}  from "../features/api";
+
 
 const SendZoopDialog = () => {
     const [open, setOpen] = useState(false);
+    const [username, setUsername] = useState("");
+    const [content, setContent] = useState("");
+    const [zoopSent, setZoopSent] = useState(false);
+    const [lastZoopSentId, setLastZoopSentId] = useState<number | null>(null);
+    const [currentUser, setCurrentUser] = useState(useGetMeQuery().data);
+
+
+    const [postZoop, { isLoading: isPostZoopLoading, isError, data: zoopData }] = usePostZoopMutation();
+    const {data: usersData, isLoading: isGetAllUsersLoading, error } = useGetAllUsersQuery() 
+
+    const navigate = useNavigate();
+
+    const handleSendZoopClick = () => {
+        if (!usersData) {
+            throw new Error('No users to send Zoop to');
+            // TODO: How best to render a message about this error in UI?
+        } else {
+            const [recipient] = usersData.users.filter(user => user.username === username);
+            if (recipient) {
+                postZoop({
+                    content: content,
+                    authorId: currentUser?.user.id,
+                    receiverId: recipient.id
+                })
+                .unwrap()
+                .then((payload) => {
+                    console.log('fulfilled', payload);
+                    setLastZoopSentId(payload.zoop.id)
+                })
+                .catch((error) => console.error('rejected', error));
+              
+                setZoopSent(true)
+            } else {
+                throw new Error('No such user exists. Please select a different username');
+                // TODO: How best to render this error in UI?
+            }
+            
+        }
+        
+    }
 
     return (
         <>
-        <Tooltip 
-            title="Send a Zoop"
-        >
-            <Fab
-                sx={{
-                    position: "absolute",
-                    bottom: 25,
-                    right: 25
-                }}
-                onClick={() => setOpen(true)}
-            > <SendIcon />
-            </Fab>
-        </Tooltip>
-        
-        <Dialog
-            open={open}
-            onClose={() => setOpen(false)}
-        >
-            <DialogTitle>Compose a Zoop</DialogTitle>
-            <DialogContent>
-                <TextField
-                    autoFocus
-                    required
-                    margin="dense"
-                    label="Recipient"
-                    type="text"
-                    placeholder="Username"    
-                />
-                <TextField
-                    required
-                    fullWidth
-                    multiline
-                    minRows={5}
-                    margin="dense"
-                    label="Content"
-                    type="text"
-                    placeholder="e.g., Zoop is the new hotness."    
-                />    
-            </DialogContent>
-            <DialogActions>
-                <Button
-                    variant="contained"
-                    endIcon={<SendIcon />}
-                    onClick={() => {
-                        setOpen(false);
-                        // TODO: redux action that adds Zoop to database
+            {/*TODO: Disable this button if user is not logged in */}
+            <Tooltip 
+                title="Send a Zoop"
+            >
+                <Fab
+                    sx={{
+                        position: "absolute",
+                        bottom: 25,
+                        right: 25
                     }}
+                    onClick={() => setOpen(true)}
+                > <SendIcon />
+                </Fab>
+            </Tooltip>
+
+            {/* Render a success dialog if Zoop was sent and successfully integrated into DB,
+                or an input dialog if Zoop has not yet been sent */}
+            {zoopSent ? (
+                <Dialog
+                    open={open}
+                    onClose={() => setOpen(false)}
                 >
-                    Send Zoop
-                </Button>
-            </DialogActions>
-        </Dialog>
+                    <DialogTitle>Compose a Zoop</DialogTitle>
+                    <DialogContent>
+                        <DialogContentText> 
+                            Zoop sent! 
+                            <Link
+                                component="button"
+                                onClick={() => navigate(`/zoops/${lastZoopSentId}`)}
+                            > 
+                                View your Zoop.
+                            </Link>
+                        </DialogContentText>
+
+                    </DialogContent>
+                </Dialog>
+            ) : (
+                <Dialog
+                    open={open}
+                    onClose={() => setOpen(false)}
+                >
+                    <DialogTitle>Compose a Zoop</DialogTitle>
+                    <DialogContent>
+                        <TextField
+                            autoFocus
+                            required
+                            margin="dense"
+                            label="Recipient"
+                            type="text"
+                            placeholder="Username"
+                            onChange={(e) => setUsername(e.target.value)}
+                            value={username}    
+                        />
+                        <TextField
+                            required
+                            fullWidth
+                            multiline
+                            minRows={5}
+                            margin="dense"
+                            label="Content"
+                            type="text"
+                            placeholder="e.g., Zoop is the new hotness."  
+                            onChange={(e) => setContent(e.target.value)}
+                            value={content}    
+                        />    
+                    </DialogContent>
+                    <DialogActions>
+                        <Button
+                            variant="contained"
+                            endIcon={<SendIcon />}
+                            onClick={handleSendZoopClick}
+                        >
+                            Send Zoop
+                        </Button>
+                    </DialogActions>
+                </Dialog>
+            )}
+            
         </>
-        )
+    )
 };
 
 export default SendZoopDialog;

--- a/client/components/SendZoopDialog.tsx
+++ b/client/components/SendZoopDialog.tsx
@@ -1,105 +1,73 @@
-import React, {useState } from "react";
-import {useNavigate} from "react-router-dom";
+import React, {useState} from "react";
 import Dialog from "@mui/material/Dialog";
 import DialogTitle from "@mui/material/DialogTitle";
 import DialogContent from "@mui/material/DialogContent";
-import DialogContentText from "@mui/material/DialogContentText"
 import DialogActions from "@mui/material/DialogActions";
 import Button from "@mui/material/Button";
 import TextField from "@mui/material/TextField";
-import Link from "@mui/material/Link";
 import Tooltip from "@mui/material/Tooltip";
 import Fab from "@mui/material/Fab";
 import SendIcon from "@mui/icons-material/Send";
-import { usePostZoopMutation}  from "../features/api";
-
 
 const SendZoopDialog = () => {
     const [open, setOpen] = useState(false);
-    const [zoopSent, setZoopSent] = useState(false);
-    const [postZoop, { isLoading, isError, data }] = usePostZoopMutation();
-
-    const navigate = useNavigate();
 
     return (
         <>
-            <Tooltip 
-                title="Send a Zoop"
-            >
-                <Fab
-                    sx={{
-                        position: "absolute",
-                        bottom: 25,
-                        right: 25
+        <Tooltip 
+            title="Send a Zoop"
+        >
+            <Fab
+                sx={{
+                    position: "absolute",
+                    bottom: 25,
+                    right: 25
+                }}
+                onClick={() => setOpen(true)}
+            > <SendIcon />
+            </Fab>
+        </Tooltip>
+        
+        <Dialog
+            open={open}
+            onClose={() => setOpen(false)}
+        >
+            <DialogTitle>Compose a Zoop</DialogTitle>
+            <DialogContent>
+                <TextField
+                    autoFocus
+                    required
+                    margin="dense"
+                    label="Recipient"
+                    type="text"
+                    placeholder="Username"    
+                />
+                <TextField
+                    required
+                    fullWidth
+                    multiline
+                    minRows={5}
+                    margin="dense"
+                    label="Content"
+                    type="text"
+                    placeholder="e.g., Zoop is the new hotness."    
+                />    
+            </DialogContent>
+            <DialogActions>
+                <Button
+                    variant="contained"
+                    endIcon={<SendIcon />}
+                    onClick={() => {
+                        setOpen(false);
+                        // TODO: redux action that adds Zoop to database
                     }}
-                    onClick={() => setOpen(true)}
-                > <SendIcon />
-                </Fab>
-            </Tooltip>
-
-            {/* Render a success dialog if Zoop was sent and successfully integrated into DB,
-                or an input dialog if Zoop has not yet been sent */}
-            {zoopSent ? (
-                <Dialog
-                    open={open}
-                    onClose={() => setOpen(false)}
                 >
-                    <DialogTitle>Compose a Zoop</DialogTitle>
-                    <DialogContent>
-                        <DialogContentText> 
-                            Zoop sent! 
-                            <Link
-                                component="button"
-                                // TODO: Setup onClick={() => navigate('')} to go to Zoop's page.
-                            > 
-                                View your Zoop.
-                            </Link>
-                        </DialogContentText>
-
-                    </DialogContent>
-                </Dialog>
-            ) : (
-                <Dialog
-                    open={open}
-                    onClose={() => setOpen(false)}
-                >
-                    <DialogTitle>Compose a Zoop</DialogTitle>
-                    <DialogContent>
-                        <TextField
-                            autoFocus
-                            required
-                            margin="dense"
-                            label="Recipient"
-                            type="text"
-                            placeholder="Username"    
-                        />
-                        <TextField
-                            required
-                            fullWidth
-                            multiline
-                            minRows={5}
-                            margin="dense"
-                            label="Content"
-                            type="text"
-                            placeholder="e.g., Zoop is the new hotness."    
-                        />    
-                    </DialogContent>
-                    <DialogActions>
-                        <Button
-                            variant="contained"
-                            endIcon={<SendIcon />}
-                            onClick={() => {;
-                                // TODO: redux action that adds Zoop to database
-                            }}
-                        >
-                            Send Zoop
-                        </Button>
-                    </DialogActions>
-                </Dialog>
-            )}
-            
+                    Send Zoop
+                </Button>
+            </DialogActions>
+        </Dialog>
         </>
-    )
+        )
 };
 
 export default SendZoopDialog;

--- a/client/components/SendZoopDialog.tsx
+++ b/client/components/SendZoopDialog.tsx
@@ -88,12 +88,14 @@ const SendZoopDialog = () => {
                         <DialogContentText> 
                             <Link
                                 component="button"
-                                onClick={() => navigate(`/zoops/${zoopData.zoop.id}`)}
+                                onClick={() => {
+                                    navigate(`/zoops/${zoopData.zoop.id}`)
+                                    setOpen(false);
+                                }}
                             > 
                                 Go to Zoop.
                             </Link>
                         </DialogContentText>
-
                     </DialogContent>
                 </Dialog>
             ) : (

--- a/client/components/SendZoopDialog.tsx
+++ b/client/components/SendZoopDialog.tsx
@@ -1,73 +1,105 @@
-import React, {useState} from "react";
+import React, {useState } from "react";
+import {useNavigate} from "react-router-dom";
 import Dialog from "@mui/material/Dialog";
 import DialogTitle from "@mui/material/DialogTitle";
 import DialogContent from "@mui/material/DialogContent";
+import DialogContentText from "@mui/material/DialogContentText"
 import DialogActions from "@mui/material/DialogActions";
 import Button from "@mui/material/Button";
 import TextField from "@mui/material/TextField";
+import Link from "@mui/material/Link";
 import Tooltip from "@mui/material/Tooltip";
 import Fab from "@mui/material/Fab";
 import SendIcon from "@mui/icons-material/Send";
+import { usePostZoopMutation}  from "../features/api";
+
 
 const SendZoopDialog = () => {
     const [open, setOpen] = useState(false);
+    const [zoopSent, setZoopSent] = useState(false);
+    const [postZoop, { isLoading, isError, data }] = usePostZoopMutation();
+
+    const navigate = useNavigate();
 
     return (
         <>
-        <Tooltip 
-            title="Send a Zoop"
-        >
-            <Fab
-                sx={{
-                    position: "absolute",
-                    bottom: 25,
-                    right: 25
-                }}
-                onClick={() => setOpen(true)}
-            > <SendIcon />
-            </Fab>
-        </Tooltip>
-        
-        <Dialog
-            open={open}
-            onClose={() => setOpen(false)}
-        >
-            <DialogTitle>Compose a Zoop</DialogTitle>
-            <DialogContent>
-                <TextField
-                    autoFocus
-                    required
-                    margin="dense"
-                    label="Recipient"
-                    type="text"
-                    placeholder="Username"    
-                />
-                <TextField
-                    required
-                    fullWidth
-                    multiline
-                    minRows={5}
-                    margin="dense"
-                    label="Content"
-                    type="text"
-                    placeholder="e.g., Zoop is the new hotness."    
-                />    
-            </DialogContent>
-            <DialogActions>
-                <Button
-                    variant="contained"
-                    endIcon={<SendIcon />}
-                    onClick={() => {
-                        setOpen(false);
-                        // TODO: redux action that adds Zoop to database
+            <Tooltip 
+                title="Send a Zoop"
+            >
+                <Fab
+                    sx={{
+                        position: "absolute",
+                        bottom: 25,
+                        right: 25
                     }}
+                    onClick={() => setOpen(true)}
+                > <SendIcon />
+                </Fab>
+            </Tooltip>
+
+            {/* Render a success dialog if Zoop was sent and successfully integrated into DB,
+                or an input dialog if Zoop has not yet been sent */}
+            {zoopSent ? (
+                <Dialog
+                    open={open}
+                    onClose={() => setOpen(false)}
                 >
-                    Send Zoop
-                </Button>
-            </DialogActions>
-        </Dialog>
+                    <DialogTitle>Compose a Zoop</DialogTitle>
+                    <DialogContent>
+                        <DialogContentText> 
+                            Zoop sent! 
+                            <Link
+                                component="button"
+                                // TODO: Setup onClick={() => navigate('')} to go to Zoop's page.
+                            > 
+                                View your Zoop.
+                            </Link>
+                        </DialogContentText>
+
+                    </DialogContent>
+                </Dialog>
+            ) : (
+                <Dialog
+                    open={open}
+                    onClose={() => setOpen(false)}
+                >
+                    <DialogTitle>Compose a Zoop</DialogTitle>
+                    <DialogContent>
+                        <TextField
+                            autoFocus
+                            required
+                            margin="dense"
+                            label="Recipient"
+                            type="text"
+                            placeholder="Username"    
+                        />
+                        <TextField
+                            required
+                            fullWidth
+                            multiline
+                            minRows={5}
+                            margin="dense"
+                            label="Content"
+                            type="text"
+                            placeholder="e.g., Zoop is the new hotness."    
+                        />    
+                    </DialogContent>
+                    <DialogActions>
+                        <Button
+                            variant="contained"
+                            endIcon={<SendIcon />}
+                            onClick={() => {;
+                                // TODO: redux action that adds Zoop to database
+                            }}
+                        >
+                            Send Zoop
+                        </Button>
+                    </DialogActions>
+                </Dialog>
+            )}
+            
         </>
-        )
+    )
 };
 
 export default SendZoopDialog;

--- a/client/components/SendZoopDialog.tsx
+++ b/client/components/SendZoopDialog.tsx
@@ -2,7 +2,6 @@ import React, {useState} from "react";
 import Dialog from "@mui/material/Dialog";
 import DialogTitle from "@mui/material/DialogTitle";
 import DialogContent from "@mui/material/DialogContent";
-import DialogContentText from "@mui/material/DialogContentText";
 import DialogActions from "@mui/material/DialogActions";
 import TextField from "@mui/material/TextField";
 import Fab from "@mui/material/Fab";
@@ -28,9 +27,6 @@ const SendZoopDialog = () => {
         >
             <DialogTitle>Compose a Zoop</DialogTitle>
             <DialogContent>
-                <DialogContentText>
-
-                </DialogContentText>
             </DialogContent>
 
         </Dialog>

--- a/client/components/SendZoopDialog.tsx
+++ b/client/components/SendZoopDialog.tsx
@@ -46,19 +46,12 @@ const SendZoopDialog = () => {
             // TODO: How best to render a message about this error in UI?
         } else {
             const [recipient] = usersData.users.filter(user => user.username === username);
-            if (recipient) {
+            if (recipient && currentUser) {
                 postZoop({
                     content: content,
-                    authorId: currentUser?.user.id,
+                    authorId: currentUser.user.id,
                     receiverId: recipient.id
                 })
-                .unwrap()
-                .then((payload) => {
-                    console.log('fulfilled', payload);
-                    setLastZoopSentId(payload.zoop.id)
-                })
-                .catch((error) => console.error('rejected', error));
-              
                 setZoopSent(true)
             } else {
                 throw new Error('No such user exists. Please select a different username');
@@ -88,7 +81,7 @@ const SendZoopDialog = () => {
 
             {/* Render a success dialog if Zoop was sent and successfully integrated into DB,
                 or an input dialog if Zoop has not yet been sent */}
-            {zoopSent ? (
+            {zoopData?.zoop ? (
                 <Dialog
                     open={open}
                     onClose={() => setOpen(false)}
@@ -98,7 +91,7 @@ const SendZoopDialog = () => {
                         <DialogContentText> 
                             <Link
                                 component="button"
-                                onClick={() => navigate(`/zoops/${lastZoopSentId}`)}
+                                onClick={() => navigate(`/zoops/${zoopData.zoop.id}`)}
                             > 
                                 Go to this page to view your Zoop.
                             </Link>

--- a/client/components/SendZoopDialog.tsx
+++ b/client/components/SendZoopDialog.tsx
@@ -1,0 +1,41 @@
+import React, {useState} from "react";
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import DialogContent from "@mui/material/DialogContent";
+import DialogContentText from "@mui/material/DialogContentText";
+import DialogActions from "@mui/material/DialogActions";
+import TextField from "@mui/material/TextField";
+import Fab from "@mui/material/Fab";
+import SendIcon from "@mui/icons-material/Send";
+
+const SendZoopDialog = () => {
+    const [open, setOpen] = useState(false);
+
+    return (
+        <>
+        <Fab
+            sx={{
+                position: "absolute",
+                bottom: 25,
+                right: 25
+            }}
+            onClick={() => setOpen(true)}
+        > <SendIcon />
+        </Fab>
+        <Dialog
+            open={open}
+            onClose={() => setOpen(false)}
+        >
+            <DialogTitle>Compose a Zoop</DialogTitle>
+            <DialogContent>
+                <DialogContentText>
+
+                </DialogContentText>
+            </DialogContent>
+
+        </Dialog>
+        </>
+        )
+};
+
+export default SendZoopDialog;

--- a/client/components/SendZoopDialog.tsx
+++ b/client/components/SendZoopDialog.tsx
@@ -8,7 +8,6 @@ import Fab from "@mui/material/Fab";
 import Link from "@mui/material/Link";
 import SendIcon from "@mui/icons-material/Send";
 import TextField from "@mui/material/TextField";
-import Tooltip from "@mui/material/Tooltip";
 import React, {
     useState,
 } from "react";
@@ -61,22 +60,18 @@ const SendZoopDialog = () => {
         
     }
 
-    return ( //TODO: MUI suggests adding a wrapper element so that Tooltip works when Fab is disabled
+    return (
         <>
-            <Tooltip 
-                title="Send a Zoop"
-            >
-                <Fab
-                    disabled={!token}
-                    sx={{
-                        position: "absolute",
-                        bottom: 25,
-                        right: 25
-                    }}
-                    onClick={() => setOpen(true)}
-                > <SendIcon />
-                </Fab>
-            </Tooltip>
+            <Fab
+                disabled={!token}
+                sx={{
+                    position: "absolute",
+                    bottom: 25,
+                    right: 25
+                }}
+                onClick={() => setOpen(true)}
+            > <SendIcon />
+            </Fab>
 
             {/* Render a success dialog if Zoop was sent and successfully integrated into DB,
                 or an input dialog if Zoop has not yet been sent */}

--- a/client/components/SendZoopDialog.tsx
+++ b/client/components/SendZoopDialog.tsx
@@ -121,7 +121,7 @@ const SendZoopDialog = () => {
                             margin="dense"
                             label="Content"
                             type="text"
-                            placeholder="e.g., Zoop is the new hotness."  
+                            placeholder="What do you want to say?"  
                             onChange={(e) => setContent(e.target.value)}
                             value={content}    
                         />    

--- a/client/components/SendZoopDialog.tsx
+++ b/client/components/SendZoopDialog.tsx
@@ -1,4 +1,7 @@
-import React, {useState } from "react";
+import React, {
+    useState,
+    useEffect 
+} from "react";
 import {useNavigate} from "react-router-dom";
 import Dialog from "@mui/material/Dialog";
 import DialogTitle from "@mui/material/DialogTitle";
@@ -16,7 +19,9 @@ import {
     useGetAllUsersQuery,
     useGetMeQuery
 }  from "../features/api";
-
+import { useSelector } from "react-redux";
+import { RootState} from "../app/store";
+import type { User } from '../../src/types/custom'
 
 const SendZoopDialog = () => {
     const [open, setOpen] = useState(false);
@@ -24,8 +29,11 @@ const SendZoopDialog = () => {
     const [content, setContent] = useState("");
     const [zoopSent, setZoopSent] = useState(false);
     const [lastZoopSentId, setLastZoopSentId] = useState<number | null>(null);
-    const [currentUser, setCurrentUser] = useState(useGetMeQuery().data);
 
+    // Variable used for authorization
+    const token = useSelector((state: RootState) => state.auth.token);
+
+    const currentUser = useGetMeQuery().data;
 
     const [postZoop, { isLoading: isPostZoopLoading, isError, data: zoopData }] = usePostZoopMutation();
     const {data: usersData, isLoading: isGetAllUsersLoading, error } = useGetAllUsersQuery() 
@@ -61,13 +69,13 @@ const SendZoopDialog = () => {
         
     }
 
-    return (
+    return ( //TODO: MUI suggests adding a wrapper element so that Tooltip works when Fab is disabled
         <>
-            {/*TODO: Disable this button if user is not logged in */}
             <Tooltip 
                 title="Send a Zoop"
             >
                 <Fab
+                    disabled={!token}
                     sx={{
                         position: "absolute",
                         bottom: 25,
@@ -85,15 +93,14 @@ const SendZoopDialog = () => {
                     open={open}
                     onClose={() => setOpen(false)}
                 >
-                    <DialogTitle>Compose a Zoop</DialogTitle>
+                    <DialogTitle>Zoop Sent!</DialogTitle>
                     <DialogContent>
                         <DialogContentText> 
-                            Zoop sent! 
                             <Link
                                 component="button"
                                 onClick={() => navigate(`/zoops/${lastZoopSentId}`)}
                             > 
-                                View your Zoop.
+                                Go to this page to view your Zoop.
                             </Link>
                         </DialogContentText>
 

--- a/client/components/SendZoopDialog.tsx
+++ b/client/components/SendZoopDialog.tsx
@@ -43,12 +43,12 @@ const SendZoopDialog = () => {
             throw new Error('No users to send Zoop to');
             // TODO: How best to render a message about this error in UI?
         } else if (!isGetAllUsersLoading && usersData) {
-            const [recipient] = usersData.users.filter(user => user.username === username);
+            const [recipient] = usersData.users.filter(el => el.user.username === username);
             if (recipient && currentUser) {
                 sendZoop({
                     content: content,
                     authorId: currentUser.user.id,
-                    receiverId: recipient.id
+                    receiverId: recipient.user.id
                 })
                 setZoopSent(true)
             } else {

--- a/client/components/SendZoopDialog.tsx
+++ b/client/components/SendZoopDialog.tsx
@@ -72,8 +72,8 @@ const SendZoopDialog = ({open, onClose}: SendZoopDialogProps) => {
                     disablePortal
                     options={usernames}
                     renderInput={(params) => <TextField {...params} label="Username" />}
-                    isOptionEqualToValue={(option, value) => option.id === value.id}
                     onChange={(e, value, reason) => setSelectedUser(value)}
+                    value={selectedUser}
                 />
                 <TextField
                     required

--- a/client/components/SendZoopDialog.tsx
+++ b/client/components/SendZoopDialog.tsx
@@ -37,6 +37,10 @@ const SendZoopDialog = ({open, onClose}: SendZoopDialogProps) => {
         console.error(zoopError);
     }
 
+    if (zoopData) {
+        console.log(zoopData);
+    }
+
     const handleSendZoopClick = () => {
         if (!isGetAllUsersLoading && !usersData) {
             throw new Error('No users to send Zoop to');
@@ -48,10 +52,6 @@ const SendZoopDialog = ({open, onClose}: SendZoopDialogProps) => {
                     authorId: currentUser.user.id,
                     receiverId: recipient.user.id
                 })
-                // TODO: figure out why zoopData is undefined.
-                if (!isSendZoopLoading && zoopData) {
-                    console.log("zoopData: ", zoopData);
-                }
             } else {
                 throw new Error('No such user exists. Please select a different username');
             }  

--- a/client/components/SendZoopDialog.tsx
+++ b/client/components/SendZoopDialog.tsx
@@ -5,6 +5,7 @@ import DialogContent from "@mui/material/DialogContent";
 import DialogActions from "@mui/material/DialogActions";
 import Button from "@mui/material/Button";
 import TextField from "@mui/material/TextField";
+import Tooltip from "@mui/material/Tooltip";
 import Fab from "@mui/material/Fab";
 import SendIcon from "@mui/icons-material/Send";
 
@@ -13,15 +14,20 @@ const SendZoopDialog = () => {
 
     return (
         <>
-        <Fab
-            sx={{
-                position: "absolute",
-                bottom: 25,
-                right: 25
-            }}
-            onClick={() => setOpen(true)}
-        > <SendIcon />
-        </Fab>
+        <Tooltip 
+            title="Send a Zoop"
+        >
+            <Fab
+                sx={{
+                    position: "absolute",
+                    bottom: 25,
+                    right: 25
+                }}
+                onClick={() => setOpen(true)}
+            > <SendIcon />
+            </Fab>
+        </Tooltip>
+        
         <Dialog
             open={open}
             onClose={() => setOpen(false)}

--- a/client/components/SendZoopDialog.tsx
+++ b/client/components/SendZoopDialog.tsx
@@ -33,7 +33,7 @@ const SendZoopDialog = ({open, onClose}: SendZoopDialogProps) => {
 
     const handleSendZoopClick = () => {
         if (!isGetAllUsersLoading && !usersData) {
-            throw new Error('No users to send Zoop to');
+            console.error('No users to send Zoop to');
         } else if (!isGetAllUsersLoading && usersData) {
             const [recipient] = usersData.users.filter(el => el.user.username === selectedUser?.label);
             if (recipient && currentUser) {
@@ -43,7 +43,7 @@ const SendZoopDialog = ({open, onClose}: SendZoopDialogProps) => {
                     receiverId: recipient.user.id
                 })
             } else {
-                throw new Error('No such user exists. Please select a different username');
+                console.error('No such user exists. Please select a different username');
             }  
         }  
     }

--- a/client/components/SendZoopDialog.tsx
+++ b/client/components/SendZoopDialog.tsx
@@ -9,7 +9,7 @@ import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
 import Snackbar from '@mui/material/Snackbar'
 import TextField from "@mui/material/TextField";
-import React, { useState } from "react";
+import React, { useState, useMemo } from "react";
 import { useSelector } from "react-redux";
 
 import { 
@@ -34,14 +34,20 @@ const SendZoopDialog = ({open, onClose}: SendZoopDialogProps) => {
 
     const currentUser = useSelector((state: RootState) => state.auth.user)
     
+    const [sendZoop, { isLoading: isSendZoopLoading, isError, data: zoopData, error: zoopError }] = useSendZoopMutation();
+    const {data: usersData, isLoading: isGetAllUsersLoading, error: userError } = useGetAllUsersQuery(); 
+
+    const userOptions = useMemo(() => {
+        return usersData ? 
+          usersData.users.map(userObject => ({label: userObject.user.username, id: userObject.user.id})) : 
+          [];
+    }, [usersData])
+
     if (!currentUser) {
         console.error("User not logged in should not have access to send zoop dialog");
         navigate('/login');
         return null;
     }
-
-    const [sendZoop, { isLoading: isSendZoopLoading, isError, data: zoopData, error: zoopError }] = useSendZoopMutation();
-    const {data: usersData, isLoading: isGetAllUsersLoading, error: userError } = useGetAllUsersQuery(); 
 
     const handleSendZoopClick = () => {
         if (!isGetAllUsersLoading && !usersData) {
@@ -75,10 +81,6 @@ const SendZoopDialog = ({open, onClose}: SendZoopDialogProps) => {
             />
         )
     }
-    
-    const usernames = usersData ? 
-        usersData.users.map(userObject => ({label: userObject.user.username, id: userObject.user.id})) : 
-        [];
 
     return (
         <>
@@ -90,7 +92,7 @@ const SendZoopDialog = ({open, onClose}: SendZoopDialogProps) => {
                 <DialogContent>
                     <Autocomplete
                         disablePortal
-                        options={usernames}
+                        options={userOptions}
                         renderInput={(params) => <TextField {...params} label="Username" />}
                         onChange={(e, value, reason) => setSelectedUser(value)}
                         value={selectedUser}

--- a/client/components/SendZoopDialog.tsx
+++ b/client/components/SendZoopDialog.tsx
@@ -62,16 +62,19 @@ const SendZoopDialog = () => {
 
     return (
         <>
-            <Fab
-                disabled={!token}
-                sx={{
-                    position: "absolute",
-                    bottom: 25,
-                    right: 25
-                }}
-                onClick={() => setOpen(true)}
-            > <SendIcon />
-            </Fab>
+            {token && (
+                <Fab
+                    disabled={!token}
+                    sx={{
+                        position: "absolute",
+                        bottom: 25,
+                        right: 25
+                    }}
+                    onClick={() => setOpen(true)}
+                > <SendIcon />
+                </Fab>
+            )}
+
 
             {/* Render a success dialog if Zoop was sent and successfully integrated into DB,
                 or an input dialog if Zoop has not yet been sent */}

--- a/client/components/SendZoopDialog.tsx
+++ b/client/components/SendZoopDialog.tsx
@@ -1,10 +1,13 @@
 import SendIcon from "@mui/icons-material/Send"
+import Alert from '@mui/material/Alert';
+import AlertTitle from '@mui/material/AlertTitle';
 import Autocomplete from "@mui/material/Autocomplete";
 import Button from "@mui/material/Button";
 import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
+import Snackbar from '@mui/material/Snackbar'
 import TextField from "@mui/material/TextField";
 import React, { useState } from "react";
 import { useSelector } from "react-redux";
@@ -15,6 +18,7 @@ import {
 } from "../features/api";
 import ZoopSentDialog from "./ZoopSentDialog";
 import { RootState } from "../app/store";
+import { useNavigate } from "react-router-dom";
 
 export interface SendZoopDialogProps {
     open: boolean
@@ -24,29 +28,44 @@ export interface SendZoopDialogProps {
 const SendZoopDialog = ({open, onClose}: SendZoopDialogProps) => {
     const [selectedUser, setSelectedUser] = useState<{label: string, id: number} | null>(null);
     const [content, setContent] = useState("");
+    const [alertOpen, setAlertOpen] = useState(false);
+
+    const navigate = useNavigate();
 
     const currentUser = useSelector((state: RootState) => state.auth.user)
+    
+    if (!currentUser) {
+        console.error("User not logged in should not have access to send zoop dialog");
+        navigate('/login');
+        return null;
+    }
 
     const [sendZoop, { isLoading: isSendZoopLoading, isError, data: zoopData, error: zoopError }] = useSendZoopMutation();
     const {data: usersData, isLoading: isGetAllUsersLoading, error: userError } = useGetAllUsersQuery(); 
-
 
     const handleSendZoopClick = () => {
         if (!isGetAllUsersLoading && !usersData) {
             console.error('No users to send Zoop to');
         } else if (!isGetAllUsersLoading && usersData) {
-            const [recipient] = usersData.users.filter(el => el.user.username === selectedUser?.label);
-            if (recipient && currentUser) {
+            if (!selectedUser) {
+                setAlertOpen(true);
+            } else {
                 sendZoop({
                     content: content,
                     authorId: currentUser.id,
-                    receiverId: recipient.user.id
+                    receiverId: selectedUser.id
                 })
-            } else {
-                console.error('No such user exists. Please select a different username');
             }  
         }  
     }
+
+    const handleClose = (event?: React.SyntheticEvent | Event, reason?: string) => {
+        if (reason === 'clickaway') {
+          return;
+        }
+    
+        setAlertOpen(false);
+      };
 
     if (zoopData) {
         return (
@@ -62,42 +81,59 @@ const SendZoopDialog = ({open, onClose}: SendZoopDialogProps) => {
         [];
 
     return (
-        <Dialog
-            open={open}
-            onClose={onClose}
-        >
-            <DialogTitle>Send Zoop</DialogTitle>
-            <DialogContent>
-                <Autocomplete
-                    disablePortal
-                    options={usernames}
-                    renderInput={(params) => <TextField {...params} label="Username" />}
-                    onChange={(e, value, reason) => setSelectedUser(value)}
-                    value={selectedUser}
-                />
-                <TextField
-                    required
-                    fullWidth
-                    multiline
-                    minRows={5}
-                    margin="dense"
-                    label="Content"
-                    type="text"
-                    placeholder="What do you want to say?"  
-                    onChange={(e) => setContent(e.target.value)}
-                    value={content}    
-                />    
-            </DialogContent>
-            <DialogActions>
-                <Button
-                    variant="contained"
-                    endIcon={<SendIcon />}
-                    onClick={handleSendZoopClick}
+        <>
+            <Dialog
+                open={open}
+                onClose={onClose}
+            >
+                <DialogTitle>Send Zoop</DialogTitle>
+                <DialogContent>
+                    <Autocomplete
+                        disablePortal
+                        options={usernames}
+                        renderInput={(params) => <TextField {...params} label="Username" />}
+                        onChange={(e, value, reason) => setSelectedUser(value)}
+                        value={selectedUser}
+                    />
+                    <TextField
+                        required
+                        fullWidth
+                        multiline
+                        minRows={5}
+                        margin="dense"
+                        label="Content"
+                        type="text"
+                        placeholder="What do you want to say?"  
+                        onChange={(e) => setContent(e.target.value)}
+                        value={content}    
+                    />    
+                </DialogContent>
+                <DialogActions>
+                    <Button
+                        variant="contained"
+                        endIcon={<SendIcon />}
+                        onClick={handleSendZoopClick}
+                    >
+                        Send Zoop
+                    </Button>
+                </DialogActions>
+            </Dialog>
+            <Snackbar
+                open={alertOpen}
+                autoHideDuration={6000} 
+                onClose={handleClose}
+            >
+                <Alert
+                    onClose={handleClose}
+                    severity="error"
                 >
-                    Send Zoop
-                </Button>
-            </DialogActions>
-        </Dialog>
+                    <AlertTitle>Error</AlertTitle>
+                    Please select user
+                </Alert>
+            </Snackbar>
+            
+        </>
+        
     )
 
 }

--- a/client/components/SendZoopDialog.tsx
+++ b/client/components/SendZoopDialog.tsx
@@ -1,27 +1,26 @@
-import React, {
-    useState,
-    useEffect 
-} from "react";
-import {useNavigate} from "react-router-dom";
+import Button from "@mui/material/Button";
 import Dialog from "@mui/material/Dialog";
-import DialogTitle from "@mui/material/DialogTitle";
+import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
 import DialogContentText from "@mui/material/DialogContentText"
-import DialogActions from "@mui/material/DialogActions";
-import Button from "@mui/material/Button";
-import TextField from "@mui/material/TextField";
-import Link from "@mui/material/Link";
-import Tooltip from "@mui/material/Tooltip";
+import DialogTitle from "@mui/material/DialogTitle";
 import Fab from "@mui/material/Fab";
+import Link from "@mui/material/Link";
 import SendIcon from "@mui/icons-material/Send";
+import TextField from "@mui/material/TextField";
+import Tooltip from "@mui/material/Tooltip";
+import React, {
+    useState,
+} from "react";
+import { useSelector } from "react-redux";
+import {useNavigate} from "react-router-dom";
+
+import { RootState} from "../app/store";
 import { 
     usePostZoopMutation, 
     useGetAllUsersQuery,
     useGetMeQuery
 }  from "../features/api";
-import { useSelector } from "react-redux";
-import { RootState} from "../app/store";
-import type { User } from '../../src/types/custom'
 
 const SendZoopDialog = () => {
     const [open, setOpen] = useState(false);

--- a/client/components/SendZoopDialog.tsx
+++ b/client/components/SendZoopDialog.tsx
@@ -35,15 +35,15 @@ const SendZoopDialog = () => {
     const currentUser = useGetMeQuery().data;
 
     const [postZoop, { isLoading: isPostZoopLoading, isError, data: zoopData }] = usePostZoopMutation();
-    const {data: usersData, isLoading: isGetAllUsersLoading, error } = useGetAllUsersQuery() 
+    const {data: usersData, isLoading: isGetAllUsersLoading, error } = useGetAllUsersQuery(); 
 
     const navigate = useNavigate();
 
     const handleSendZoopClick = () => {
-        if (!usersData) {
+        if (!isGetAllUsersLoading && !usersData) {
             throw new Error('No users to send Zoop to');
             // TODO: How best to render a message about this error in UI?
-        } else {
+        } else if (!isGetAllUsersLoading && usersData) {
             const [recipient] = usersData.users.filter(user => user.username === username);
             if (recipient && currentUser) {
                 postZoop({

--- a/client/components/SendZoopDialog.tsx
+++ b/client/components/SendZoopDialog.tsx
@@ -22,7 +22,7 @@ export interface SendZoopDialogProps {
 }
 
 const SendZoopDialog = ({open, onClose}: SendZoopDialogProps) => {
-    const [username, setUsername] = useState<{label: string, id: number} | null>(null);
+    const [selectedUser, setSelectedUser] = useState<{label: string, id: number} | null>(null);
     const [content, setContent] = useState("");
 
     const currentUser = useSelector((state: RootState) => state.auth.user)
@@ -35,7 +35,7 @@ const SendZoopDialog = ({open, onClose}: SendZoopDialogProps) => {
         if (!isGetAllUsersLoading && !usersData) {
             throw new Error('No users to send Zoop to');
         } else if (!isGetAllUsersLoading && usersData) {
-            const [recipient] = usersData.users.filter(el => el.user.username === username?.label);
+            const [recipient] = usersData.users.filter(el => el.user.username === selectedUser?.label);
             if (recipient && currentUser) {
                 sendZoop({
                     content: content,
@@ -73,7 +73,7 @@ const SendZoopDialog = ({open, onClose}: SendZoopDialogProps) => {
                     options={usernames}
                     renderInput={(params) => <TextField {...params} label="Username" />}
                     isOptionEqualToValue={(option, value) => option.id === value.id}
-                    onChange={(e, value, reason) => setUsername(value)}
+                    onChange={(e, value, reason) => setSelectedUser(value)}
                 />
                 <TextField
                     required

--- a/client/components/SendZoopDialog.tsx
+++ b/client/components/SendZoopDialog.tsx
@@ -16,7 +16,7 @@ import {useNavigate} from "react-router-dom";
 
 import { RootState} from "../app/store";
 import { 
-    usePostZoopMutation, 
+    useSendZoopMutation, 
     useGetAllUsersQuery,
     useGetMeQuery
 }  from "../features/api";
@@ -33,7 +33,7 @@ const SendZoopDialog = () => {
 
     const currentUser = useGetMeQuery().data;
 
-    const [postZoop, { isLoading: isPostZoopLoading, isError, data: zoopData }] = usePostZoopMutation();
+    const [sendZoop, { isLoading: isPostZoopLoading, isError, data: zoopData }] = useSendZoopMutation();
     const {data: usersData, isLoading: isGetAllUsersLoading, error } = useGetAllUsersQuery(); 
 
     const navigate = useNavigate();
@@ -45,7 +45,7 @@ const SendZoopDialog = () => {
         } else if (!isGetAllUsersLoading && usersData) {
             const [recipient] = usersData.users.filter(user => user.username === username);
             if (recipient && currentUser) {
-                postZoop({
+                sendZoop({
                     content: content,
                     authorId: currentUser.user.id,
                     receiverId: recipient.id

--- a/client/components/SendZoopDialog.tsx
+++ b/client/components/SendZoopDialog.tsx
@@ -3,6 +3,7 @@ import Dialog from "@mui/material/Dialog";
 import DialogTitle from "@mui/material/DialogTitle";
 import DialogContent from "@mui/material/DialogContent";
 import DialogActions from "@mui/material/DialogActions";
+import Button from "@mui/material/Button";
 import TextField from "@mui/material/TextField";
 import Fab from "@mui/material/Fab";
 import SendIcon from "@mui/icons-material/Send";
@@ -27,8 +28,35 @@ const SendZoopDialog = () => {
         >
             <DialogTitle>Compose a Zoop</DialogTitle>
             <DialogContent>
+                <TextField
+                    autoFocus
+                    required
+                    margin="dense"
+                    label="Recipient"
+                    type="text"
+                    placeholder="Username"    
+                />
+                <TextField
+                    autoFocus
+                    required
+                    margin="dense"
+                    label="Content"
+                    type="text"
+                    placeholder="e.g., Zoop is the zoopiest of all apps."    
+                />    
             </DialogContent>
-
+            <DialogActions>
+                <Button
+                    variant="contained"
+                    endIcon={<SendIcon />}
+                    onClick={() => {
+                        setOpen(false);
+                        // TODO: redux action that adds Zoop to database
+                    }}
+                >
+                    Send Zoop
+                </Button>
+            </DialogActions>
         </Dialog>
         </>
         )

--- a/client/components/SendZoopDialog.tsx
+++ b/client/components/SendZoopDialog.tsx
@@ -90,7 +90,7 @@ const SendZoopDialog = () => {
                                 component="button"
                                 onClick={() => navigate(`/zoops/${zoopData.zoop.id}`)}
                             > 
-                                Go to this page to view your Zoop.
+                                Go to Zoop.
                             </Link>
                         </DialogContentText>
 
@@ -101,7 +101,7 @@ const SendZoopDialog = () => {
                     open={open}
                     onClose={() => setOpen(false)}
                 >
-                    <DialogTitle>Compose a Zoop</DialogTitle>
+                    <DialogTitle>Send Zoop</DialogTitle>
                     <DialogContent>
                         <TextField
                             autoFocus

--- a/client/components/SendZoopDialog.tsx
+++ b/client/components/SendZoopDialog.tsx
@@ -67,7 +67,7 @@ const SendZoopDialog = () => {
                     disabled={!token}
                     sx={{
                         position: "absolute",
-                        bottom: 25,
+                        top: 25,
                         right: 25
                     }}
                     onClick={() => setOpen(true)}

--- a/client/components/SendZoopDialog.tsx
+++ b/client/components/SendZoopDialog.tsx
@@ -1,47 +1,39 @@
+import SendIcon from "@mui/icons-material/Send"
 import Button from "@mui/material/Button";
 import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
-import DialogContentText from "@mui/material/DialogContentText"
 import DialogTitle from "@mui/material/DialogTitle";
-import Fab from "@mui/material/Fab";
-import Link from "@mui/material/Link";
-import SendIcon from "@mui/icons-material/Send";
 import TextField from "@mui/material/TextField";
-import React, {
-    useState,
-} from "react";
-import { useSelector } from "react-redux";
-import {useNavigate} from "react-router-dom";
+import React, { useState } from "react";
 
-import { RootState} from "../app/store";
 import { 
-    useSendZoopMutation, 
-    useGetAllUsersQuery,
-    useGetMeQuery
-}  from "../features/api";
+    useGetAllUsersQuery, 
+    useGetMeQuery, 
+    useSendZoopMutation 
+} from "../features/api";
+import { Zoop } from "../../src/types/custom";
 
-const SendZoopDialog = () => {
-    const [open, setOpen] = useState(false);
+export interface SendZoopDialogProps {
+    openDialog: boolean
+    isZoopSent: () => void
+    sentZoop: (zoop: Zoop) => void;
+}
+
+const SendZoopDialog = ({openDialog, isZoopSent, sentZoop}: SendZoopDialogProps) => {
     const [username, setUsername] = useState("");
     const [content, setContent] = useState("");
-    const [zoopSent, setZoopSent] = useState(false);
-    const [lastZoopSentId, setLastZoopSentId] = useState<number | null>(null);
-
-    // Variable used for authorization
-    const token = useSelector((state: RootState) => state.auth.token);
+    const [open, setOpen] = useState(openDialog);
 
     const currentUser = useGetMeQuery().data;
 
-    const [sendZoop, { isLoading: isPostZoopLoading, isError, data: zoopData }] = useSendZoopMutation();
+    const [sendZoop, { isLoading: isSendZoopLoading, isError, data: zoopData }] = useSendZoopMutation();
     const {data: usersData, isLoading: isGetAllUsersLoading, error } = useGetAllUsersQuery(); 
 
-    const navigate = useNavigate();
-
     const handleSendZoopClick = () => {
+        setOpen(false);
         if (!isGetAllUsersLoading && !usersData) {
             throw new Error('No users to send Zoop to');
-            // TODO: How best to render a message about this error in UI?
         } else if (!isGetAllUsersLoading && usersData) {
             const [recipient] = usersData.users.filter(el => el.user.username === username);
             if (recipient && currentUser) {
@@ -50,98 +42,60 @@ const SendZoopDialog = () => {
                     authorId: currentUser.user.id,
                     receiverId: recipient.user.id
                 })
-                setZoopSent(true)
+                isZoopSent();
+                // TODO: figure out why zoopData is undefined.
+                if (!isSendZoopLoading && zoopData) {
+                    console.log("zoopData: ", zoopData);
+                    sentZoop(zoopData.zoop);
+                }
             } else {
                 throw new Error('No such user exists. Please select a different username');
-                // TODO: How best to render this error in UI?
-            }
-            
-        }
-        
+            }  
+        }  
     }
 
     return (
-        <>
-            {token && (
-                <Fab
-                    disabled={!token}
-                    sx={{
-                        position: "absolute",
-                        top: 25,
-                        right: 25
-                    }}
-                    onClick={() => setOpen(true)}
-                > <SendIcon />
-                </Fab>
-            )}
-
-
-            {/* Render a success dialog if Zoop was sent and successfully integrated into DB,
-                or an input dialog if Zoop has not yet been sent */}
-            {zoopData?.zoop ? (
-                <Dialog
-                    open={open}
-                    onClose={() => setOpen(false)}
+        <Dialog
+            open={open}
+            onClose={() => setOpen(false)}
+        >
+            <DialogTitle>Send Zoop</DialogTitle>
+            <DialogContent>
+                <TextField
+                    autoFocus
+                    required
+                    margin="dense"
+                    label="Recipient"
+                    type="text"
+                    placeholder="Username"
+                    onChange={(e) => setUsername(e.target.value)}
+                    value={username}    
+                />
+                <TextField
+                    required
+                    fullWidth
+                    multiline
+                    minRows={5}
+                    margin="dense"
+                    label="Content"
+                    type="text"
+                    placeholder="What do you want to say?"  
+                    onChange={(e) => setContent(e.target.value)}
+                    value={content}    
+                />    
+            </DialogContent>
+            <DialogActions>
+                <Button
+                    variant="contained"
+                    endIcon={<SendIcon />}
+                    onClick={handleSendZoopClick}
                 >
-                    <DialogTitle>Zoop Sent!</DialogTitle>
-                    <DialogContent>
-                        <DialogContentText> 
-                            <Link
-                                component="button"
-                                onClick={() => {
-                                    navigate(`/zoops/${zoopData.zoop.id}`)
-                                    setOpen(false);
-                                }}
-                            > 
-                                Go to Zoop.
-                            </Link>
-                        </DialogContentText>
-                    </DialogContent>
-                </Dialog>
-            ) : (
-                <Dialog
-                    open={open}
-                    onClose={() => setOpen(false)}
-                >
-                    <DialogTitle>Send Zoop</DialogTitle>
-                    <DialogContent>
-                        <TextField
-                            autoFocus
-                            required
-                            margin="dense"
-                            label="Recipient"
-                            type="text"
-                            placeholder="Username"
-                            onChange={(e) => setUsername(e.target.value)}
-                            value={username}    
-                        />
-                        <TextField
-                            required
-                            fullWidth
-                            multiline
-                            minRows={5}
-                            margin="dense"
-                            label="Content"
-                            type="text"
-                            placeholder="What do you want to say?"  
-                            onChange={(e) => setContent(e.target.value)}
-                            value={content}    
-                        />    
-                    </DialogContent>
-                    <DialogActions>
-                        <Button
-                            variant="contained"
-                            endIcon={<SendIcon />}
-                            onClick={handleSendZoopClick}
-                        >
-                            Send Zoop
-                        </Button>
-                    </DialogActions>
-                </Dialog>
-            )}
-            
-        </>
+                    Send Zoop
+                </Button>
+            </DialogActions>
+        </Dialog>
     )
-};
+
+}
 
 export default SendZoopDialog;

--- a/client/components/Zoop.tsx
+++ b/client/components/Zoop.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { useParams } from "react-router-dom";
-import SendZoopDialog from "./SendZoopDialog";
 
 const Zoop = () => {
   const { id } = useParams();
@@ -8,7 +7,6 @@ const Zoop = () => {
     return(
         <>
             <div>This is the page for Zoop # {id}</div>
-            <SendZoopDialog />
         </>
     )
 }

--- a/client/components/Zoop.tsx
+++ b/client/components/Zoop.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useParams } from "react-router-dom";
+import SendZoopDialog from "./SendZoopDialog";
 
 const Zoop = () => {
   const { id } = useParams();
@@ -7,6 +8,7 @@ const Zoop = () => {
     return(
         <>
             <div>This is the page for Zoop # {id}</div>
+            <SendZoopDialog />
         </>
     )
 }

--- a/client/components/ZoopSentDialog.tsx
+++ b/client/components/ZoopSentDialog.tsx
@@ -1,0 +1,45 @@
+import Dialog from "@mui/material/Dialog";
+import DialogContent from "@mui/material/DialogContent";
+import DialogContentText from "@mui/material/DialogContentText";
+import DialogTitle from "@mui/material/DialogTitle";
+import Link from "@mui/material/Link";
+import React, {useState} from "react";
+import { useNavigate } from "react-router-dom";
+import { Zoop } from "../../src/types/custom";
+
+
+export interface ZoopSentDialogProps {
+    isZoopSent: boolean
+    sentZoop: Zoop | null
+}
+
+const ZoopSentDialog = ({isZoopSent, sentZoop}: ZoopSentDialogProps) => {
+    const [open, setOpen] = useState(isZoopSent);
+    
+    const navigate = useNavigate()
+
+    return (
+        <Dialog
+            open={open}
+            onClose={() => setOpen(false)}
+        >
+            <DialogTitle>Zoop Sent!</DialogTitle>
+            <DialogContent>
+                <DialogContentText> 
+                    <Link
+                        component="button"
+                        onClick={() => {
+                            navigate(`/zoops/${sentZoop?.id}`)
+                            setOpen(false);
+                        }}
+                    > 
+                        Go to Zoop.
+                    </Link>
+                </DialogContentText>
+            </DialogContent>
+        </Dialog>
+    )
+
+}
+
+export default ZoopSentDialog;

--- a/client/components/ZoopSentDialog.tsx
+++ b/client/components/ZoopSentDialog.tsx
@@ -9,19 +9,18 @@ import { Zoop } from "../../src/types/custom";
 
 
 export interface ZoopSentDialogProps {
-    isZoopSent: boolean
-    sentZoop: Zoop | null
+    sentZoop: Zoop
+    onClose: () => void
 }
 
-const ZoopSentDialog = ({isZoopSent, sentZoop}: ZoopSentDialogProps) => {
-    const [open, setOpen] = useState(isZoopSent);
+const ZoopSentDialog = ({sentZoop, onClose}: ZoopSentDialogProps) => {
     
     const navigate = useNavigate()
 
     return (
         <Dialog
-            open={open}
-            onClose={() => setOpen(false)}
+            open={true}
+            onClose={onClose}
         >
             <DialogTitle>Zoop Sent!</DialogTitle>
             <DialogContent>
@@ -29,8 +28,8 @@ const ZoopSentDialog = ({isZoopSent, sentZoop}: ZoopSentDialogProps) => {
                     <Link
                         component="button"
                         onClick={() => {
-                            navigate(`/zoops/${sentZoop?.id}`)
-                            setOpen(false);
+                            navigate(`/zoops/${sentZoop.id}`)
+                            onClose();
                         }}
                     > 
                         Go to Zoop.

--- a/client/components/ZoopSentDialog.tsx
+++ b/client/components/ZoopSentDialog.tsx
@@ -1,11 +1,12 @@
+import Button from '@mui/material/Button';
 import Dialog from "@mui/material/Dialog";
 import DialogContent from "@mui/material/DialogContent";
 import DialogContentText from "@mui/material/DialogContentText";
 import DialogTitle from "@mui/material/DialogTitle";
-import Link from "@mui/material/Link";
-import React, {useState} from "react";
-import { useNavigate } from "react-router-dom";
+import {Link} from "react-router-dom";
+import React from "react";
 import { Zoop } from "../../src/types/custom";
+import { Typography } from '@mui/material';
 
 
 export interface ZoopSentDialogProps {
@@ -15,7 +16,6 @@ export interface ZoopSentDialogProps {
 
 const ZoopSentDialog = ({sentZoop, onClose}: ZoopSentDialogProps) => {
     
-    const navigate = useNavigate()
 
     return (
         <Dialog
@@ -26,14 +26,19 @@ const ZoopSentDialog = ({sentZoop, onClose}: ZoopSentDialogProps) => {
             <DialogContent>
                 <DialogContentText> 
                     <Link
-                        component="button"
-                        onClick={() => {
-                            navigate(`/zoops/${sentZoop.id}`)
-                            onClose();
-                        }}
-                    > 
-                        Go to Zoop.
+                        to={`/zoops/${sentZoop.id}`}    
+                    >
+                        <Button
+                            type="button"
+                            variant='contained'
+                            onClick={() => {
+                                onClose();
+                            }}
+                        > 
+                            <Typography>Go to Zoop</Typography>
+                        </Button>
                     </Link>
+                    
                 </DialogContentText>
             </DialogContent>
         </Dialog>

--- a/client/features/api.tsx
+++ b/client/features/api.tsx
@@ -37,7 +37,7 @@ export const api = createApi({
         query: () => `/zoops`,
         providesTags: ['Zoop']
       }),
-      postZoop: builder.mutation<{zoop: Zoop}, {content: string, authorId: number, receiverId: number}>({
+      sendZoop: builder.mutation<{zoop: Zoop}, {content: string, authorId: number, receiverId: number}>({
         query: ({content, authorId, receiverId}) => ({
           url: "/zoops",
           method: "POST",
@@ -65,7 +65,7 @@ export const api = createApi({
     useGetAllZoopsQuery, 
     useRegisterMutation,
     useLoginMutation,
-    usePostZoopMutation,
+    useSendZoopMutation,
     useGetAllUsersQuery,
     useGetMeQuery 
   } = api

--- a/client/features/api.tsx
+++ b/client/features/api.tsx
@@ -37,7 +37,7 @@ export const api = createApi({
         query: () => `/zoops`,
         providesTags: ['Zoop']
       }),
-      postZoop: builder.mutation({
+      postZoop: builder.mutation<{zoop: Zoop}, {content: string, authorId: number, receiverId: number}>({
         query: ({content, authorId, receiverId}) => ({
           url: "/zoops",
           method: "POST",

--- a/client/features/api.tsx
+++ b/client/features/api.tsx
@@ -4,40 +4,48 @@ import { RootState } from '../app/store';
 
 // Define a service using a base URL and expected endpoints
 export const api = createApi({
-    reducerPath: 'api',
-    baseQuery: fetchBaseQuery({
-        baseUrl: 'http://localhost:3000/api', 
-        prepareHeaders: (headers: Headers, { getState }) => {
-          const token = (getState() as RootState).auth.token;
-          if (token) {
-            headers.set("Authorization", `Bearer ${token}`);
-          }
-          return headers;
-        },
+  reducerPath: 'api',
+  baseQuery: fetchBaseQuery({
+      baseUrl: 'http://localhost:3000/api', 
+      prepareHeaders: (headers: Headers, { getState }) => {
+        const token = (getState() as RootState).auth.token;
+        if (token) {
+          headers.set("Authorization", `Bearer ${token}`);
+        }
+        return headers;
+      },
+    }),
+    tagTypes: ['CurrentUser', 'Zoop', 'Fave', 'User'],
+    endpoints: (builder) => ({
+      register: builder.mutation({
+        query: ({ email, username, password }) => ({
+          url: "users/register",
+          method: "POST",
+          body: { email, username, password },
+        }),
+        invalidatesTags: ["CurrentUser"],
       }),
-      tagTypes: ['CurrentUser', 'Zoop', 'Fave'],
-      endpoints: (builder) => ({
-        register: builder.mutation({
-          query: ({ email, username, password }) => ({
-            url: "users/register",
-            method: "POST",
-            body: { email, username, password },
-          }),
-          invalidatesTags: ["CurrentUser"],
+      login: builder.mutation({
+        query: ({ email, password }) => ({
+          url: "users/login",
+          method: "POST",
+          body: { email, password },
         }),
-        login: builder.mutation({
-          query: ({ email, password }) => ({
-            url: "users/login",
-            method: "POST",
-            body: { email, password },
-          }),
-          invalidatesTags: ["CurrentUser"],
-        }),
-        getAllZoops: builder.query<{zoops: Zoop[]}, void>({
-          query: () => `/zoops`,
-          providesTags: ['Zoop']
-        }),
+        invalidatesTags: ["CurrentUser"],
       }),
+      getAllZoops: builder.query<{zoops: Zoop[]}, void>({
+        query: () => `/zoops`,
+        providesTags: ['Zoop']
+      }),
+      postZoop: builder.mutation({
+        query: ({content, authorId, receiverId}) => ({
+          url: "/zoops",
+          method: "POST",
+          body: {content, authorId, receiverId},
+        }),
+        invalidatesTags: ["Zoop"],
+      }),
+    }),
   })
   
   // Export hooks for usage in functional components, which are
@@ -48,5 +56,6 @@ export const api = createApi({
   export const { 
     useGetAllZoopsQuery, 
     useRegisterMutation,
-    useLoginMutation 
+    useLoginMutation,
+    usePostZoopMutation 
   } = api

--- a/client/features/api.tsx
+++ b/client/features/api.tsx
@@ -4,48 +4,40 @@ import { RootState } from '../app/store';
 
 // Define a service using a base URL and expected endpoints
 export const api = createApi({
-  reducerPath: 'api',
-  baseQuery: fetchBaseQuery({
-      baseUrl: 'http://localhost:3000/api', 
-      prepareHeaders: (headers: Headers, { getState }) => {
-        const token = (getState() as RootState).auth.token;
-        if (token) {
-          headers.set("Authorization", `Bearer ${token}`);
-        }
-        return headers;
-      },
-    }),
-    tagTypes: ['CurrentUser', 'Zoop', 'Fave', 'User'],
-    endpoints: (builder) => ({
-      register: builder.mutation({
-        query: ({ email, username, password }) => ({
-          url: "users/register",
-          method: "POST",
-          body: { email, username, password },
+    reducerPath: 'api',
+    baseQuery: fetchBaseQuery({
+        baseUrl: 'http://localhost:3000/api', 
+        prepareHeaders: (headers: Headers, { getState }) => {
+          const token = (getState() as RootState).auth.token;
+          if (token) {
+            headers.set("Authorization", `Bearer ${token}`);
+          }
+          return headers;
+        },
+      }),
+      tagTypes: ['CurrentUser', 'Zoop', 'Fave'],
+      endpoints: (builder) => ({
+        register: builder.mutation({
+          query: ({ email, username, password }) => ({
+            url: "users/register",
+            method: "POST",
+            body: { email, username, password },
+          }),
+          invalidatesTags: ["CurrentUser"],
         }),
-        invalidatesTags: ["CurrentUser"],
-      }),
-      login: builder.mutation({
-        query: ({ email, password }) => ({
-          url: "users/login",
-          method: "POST",
-          body: { email, password },
+        login: builder.mutation({
+          query: ({ email, password }) => ({
+            url: "users/login",
+            method: "POST",
+            body: { email, password },
+          }),
+          invalidatesTags: ["CurrentUser"],
         }),
-        invalidatesTags: ["CurrentUser"],
-      }),
-      getAllZoops: builder.query<{zoops: Zoop[]}, void>({
-        query: () => `/zoops`,
-        providesTags: ['Zoop']
-      }),
-      postZoop: builder.mutation({
-        query: ({content, authorId, receiverId}) => ({
-          url: "/zoops",
-          method: "POST",
-          body: {content, authorId, receiverId},
+        getAllZoops: builder.query<{zoops: Zoop[]}, void>({
+          query: () => `/zoops`,
+          providesTags: ['Zoop']
         }),
-        invalidatesTags: ["Zoop"],
       }),
-    }),
   })
   
   // Export hooks for usage in functional components, which are
@@ -56,6 +48,5 @@ export const api = createApi({
   export const { 
     useGetAllZoopsQuery, 
     useRegisterMutation,
-    useLoginMutation,
-    usePostZoopMutation 
+    useLoginMutation 
   } = api

--- a/client/features/api.tsx
+++ b/client/features/api.tsx
@@ -45,7 +45,7 @@ export const api = createApi({
         }),
         invalidatesTags: ["Zoop"],
       }),
-      getAllUsers: builder.query<{users: User[]}, void>({
+      getAllUsers: builder.query<{users: {user: User}[]}, void>({
         query: () => `/users`,
         providesTags: ['User']
       }),

--- a/client/features/api.tsx
+++ b/client/features/api.tsx
@@ -4,40 +4,56 @@ import { RootState } from '../app/store';
 
 // Define a service using a base URL and expected endpoints
 export const api = createApi({
-    reducerPath: 'api',
-    baseQuery: fetchBaseQuery({
-        baseUrl: 'http://localhost:3000/api', 
-        prepareHeaders: (headers: Headers, { getState }) => {
-          const token = (getState() as RootState).auth.token;
-          if (token) {
-            headers.set("Authorization", `Bearer ${token}`);
-          }
-          return headers;
-        },
+  reducerPath: 'api',
+  baseQuery: fetchBaseQuery({
+      baseUrl: 'http://localhost:3000/api', 
+      prepareHeaders: (headers: Headers, { getState }) => {
+        const token = (getState() as RootState).auth.token;
+        if (token) {
+          headers.set("Authorization", `Bearer ${token}`);
+        }
+        return headers;
+      },
+    }),
+    tagTypes: ['CurrentUser', 'Zoop', 'Fave', 'User'],
+    endpoints: (builder) => ({
+      register: builder.mutation({
+        query: ({ email, username, password }) => ({
+          url: "users/register",
+          method: "POST",
+          body: { email, username, password },
+        }),
+        invalidatesTags: ["CurrentUser"],
       }),
-      tagTypes: ['CurrentUser', 'Zoop', 'Fave'],
-      endpoints: (builder) => ({
-        register: builder.mutation({
-          query: ({ email, username, password }) => ({
-            url: "users/register",
-            method: "POST",
-            body: { email, username, password },
-          }),
-          invalidatesTags: ["CurrentUser"],
+      login: builder.mutation({
+        query: ({ email, password }) => ({
+          url: "users/login",
+          method: "POST",
+          body: { email, password },
         }),
-        login: builder.mutation({
-          query: ({ email, password }) => ({
-            url: "users/login",
-            method: "POST",
-            body: { email, password },
-          }),
-          invalidatesTags: ["CurrentUser"],
-        }),
-        getAllZoops: builder.query<{zoops: Zoop[]}, void>({
-          query: () => `/zoops`,
-          providesTags: ['Zoop']
-        }),
+        invalidatesTags: ["CurrentUser"],
       }),
+      getAllZoops: builder.query<{zoops: Zoop[]}, void>({
+        query: () => `/zoops`,
+        providesTags: ['Zoop']
+      }),
+      postZoop: builder.mutation({
+        query: ({content, authorId, receiverId}) => ({
+          url: "/zoops",
+          method: "POST",
+          body: {content, authorId, receiverId},
+        }),
+        invalidatesTags: ["Zoop"],
+      }),
+      getAllUsers: builder.query<{users: User[]}, void>({
+        query: () => `/users`,
+        providesTags: ['User']
+      }),
+      getMe: builder.query<{user: User}, void>({
+        query: () => `/users/me`,
+        providesTags: ['CurrentUser']
+      }),
+    }),
   })
   
   // Export hooks for usage in functional components, which are
@@ -48,5 +64,8 @@ export const api = createApi({
   export const { 
     useGetAllZoopsQuery, 
     useRegisterMutation,
-    useLoginMutation 
+    useLoginMutation,
+    usePostZoopMutation,
+    useGetAllUsersQuery,
+    useGetMeQuery 
   } = api

--- a/client/features/authSlice.tsx
+++ b/client/features/authSlice.tsx
@@ -23,11 +23,13 @@ const authSlice = createSlice({
       api.endpoints.register.matchFulfilled,
       (state, { payload }) => {
         state.token = payload.token;
+        state.user = payload.user;
       }
     );
     builder.addMatcher(
       api.endpoints.login.matchFulfilled, (state, { payload }) => {
         state.token = payload.token;
+        state.user = payload.user;
       }
     );
   }

--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -34,13 +34,11 @@ usersRouter.get("/me", requireUser, async (req, res, next): Promise<void> => {
 
 // GET /api/users
 usersRouter.get("/", async (req, res, next): Promise<void> => {
-    // if (req.user) {
-        try {
-            const users = await prisma.user.findMany();
-            res.send({users});
-        } catch (e) {
-            next(e);
-        // }
+    try {
+        const users = await prisma.user.findMany();
+        res.send({users: users.map(user => ({user: excludePassword(user)}))});
+    } catch (e) {
+        next(e);
     }
 })
 
@@ -65,10 +63,7 @@ usersRouter.post("/register", async (req, res, next) => {
         
         res.send({
             token,
-            user: {
-                ...user,
-                password: undefined
-            }
+            user: excludePassword(user)
         });
     })
     } catch (e) {
@@ -99,10 +94,7 @@ usersRouter.post("/login", async (req, res, next) => {
                 
                 res.send({
                     token,
-                    user: {
-                        ...user,
-                        password: undefined
-                    }
+                    user: excludePassword(user)
                 });
             } else {
                 next({name: "IncorrectPassword", message: "The password you entered is incorrect"})

--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -32,6 +32,18 @@ usersRouter.get("/me", requireUser, async (req, res, next): Promise<void> => {
     }
 })
 
+// GET /api/users
+usersRouter.get("/", requireUser, async (req, res, next): Promise<void> => {
+    if (req.user) {
+        try {
+            const users = await prisma.user.findMany();
+            res.send({users});
+        } catch (e) {
+            next(e);
+        }
+    }
+})
+
 // POST /api/users/register
 usersRouter.post("/register", async (req, res, next) => {
     try {

--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -32,18 +32,6 @@ usersRouter.get("/me", requireUser, async (req, res, next): Promise<void> => {
     }
 })
 
-// GET /api/users
-usersRouter.get("/", requireUser, async (req, res, next): Promise<void> => {
-    if (req.user) {
-        try {
-            const users = await prisma.user.findMany();
-            res.send({users});
-        } catch (e) {
-            next(e);
-        }
-    }
-})
-
 // POST /api/users/register
 usersRouter.post("/register", async (req, res, next) => {
     try {

--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -33,14 +33,14 @@ usersRouter.get("/me", requireUser, async (req, res, next): Promise<void> => {
 })
 
 // GET /api/users
-usersRouter.get("/", requireUser, async (req, res, next): Promise<void> => {
-    if (req.user) {
+usersRouter.get("/", async (req, res, next): Promise<void> => {
+    // if (req.user) {
         try {
             const users = await prisma.user.findMany();
             res.send({users});
         } catch (e) {
             next(e);
-        }
+        // }
     }
 })
 

--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -33,12 +33,14 @@ usersRouter.get("/me", requireUser, async (req, res, next): Promise<void> => {
 })
 
 // GET /api/users
-usersRouter.get("/", async (req, res, next): Promise<void> => {
-    try {
-        const users = await prisma.user.findMany();
-        res.send({users: users.map(user => ({user: excludePassword(user)}))});
-    } catch (e) {
-        next(e);
+usersRouter.get("/", requireUser, async (req, res, next): Promise<void> => {
+    if (req.user) {
+        try {
+            const users = await prisma.user.findMany();
+            res.send({users: users.map(user => ({user: excludePassword(user)}))});
+        } catch (e) {
+            next(e);
+        }
     }
 })
 

--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -66,8 +66,8 @@ usersRouter.post("/register", async (req, res, next) => {
         res.send({
             token,
             user: {
-                email: user.email,
-                username: user.username
+                ...user,
+                password: undefined
             }
         });
     })
@@ -100,8 +100,8 @@ usersRouter.post("/login", async (req, res, next) => {
                 res.send({
                     token,
                     user: {
-                        email: user.email,
-                        username: user.username
+                        ...user,
+                        password: undefined
                     }
                 });
             } else {

--- a/src/types/custom.ts
+++ b/src/types/custom.ts
@@ -1,12 +1,6 @@
-export type User = {
-        id: number
-        email: string
-        dateCreated: Date
-        username: string        
-        zoopsWritten: Zoop[]
-        zoopsReceived: Zoop[]
-        faves: Fave[]
-}
+import type { User as UserFromPrisma} from '@prisma/client';
+
+export type User = Omit<UserFromPrisma, "password">;
 
 export interface Fave {
         id: number


### PR DESCRIPTION
Closes #58 

There is now a floating action button to send a Zoop, which is only enabled if you are an authenticated user. A dialog pops up to compose the Zoop. Below are screenshots of testing.

I created a new GET all users endpoint in order to complete this feature. Here it is tested on Postman (it requires an authenticated user to access):
![Screen Shot 2023-11-16 at 01 24 35](https://github.com/dyazdani/zoop/assets/99094815/2cef4e25-4b9b-43c4-bc1f-ef4a3d61a5a4)

The Send Zoop button is only enabled when the user has a token from logging in and shows up on all pages:
![Screen Shot 2023-11-21 at 22 51 53](https://github.com/dyazdani/zoop/assets/99094815/eaa1f604-5942-41d7-a6ba-4ad18503e95c)

The Send Zoop dialog:
![Screen Shot 2023-11-21 at 22 52 22](https://github.com/dyazdani/zoop/assets/99094815/676f0e7b-d21d-4735-af26-a9aeee8dc0b8)
The "Username" label on the Autocomplete field gets cut off when you click inside the element. I have an Issue to fix that:
![Screen Shot 2023-11-21 at 22 53 09](https://github.com/dyazdani/zoop/assets/99094815/e8b42845-8cfd-4236-8662-8cb088b15f76)
![Screen Shot 2023-11-21 at 22 52 31](https://github.com/dyazdani/zoop/assets/99094815/845db8a4-a892-41f3-8314-6a89639d6790)

When the Zoop is successfully sent, the dialog changes and gives you a button linked to the Zoop:
![Screen Shot 2023-11-21 at 22 53 15](https://github.com/dyazdani/zoop/assets/99094815/9dc6d200-d6fb-421c-afac-28a2c8a71472)
![Screen Shot 2023-11-21 at 22 53 22](https://github.com/dyazdani/zoop/assets/99094815/74ab2602-5489-4417-a36f-15d6b2503e11)



https://github.com/dyazdani/zoop/assets/99094815/5eeab7f9-331c-45e4-9225-1f5439a56b42